### PR TITLE
Fix: [DEV3-5002] Add cleanup step to remove settings.json for self-hosted runners

### DIFF
--- a/Bitbucket/bitbucket-pipelines.yml
+++ b/Bitbucket/bitbucket-pipelines.yml
@@ -10,7 +10,7 @@
 # Optional Repository Variables:
 #   TABNINE_HOST           - Tabnine host URL (default: https://console.tabnine.com)
 #   TABNINE_MODEL_ID       - Model ID for the Tabnine CLI agent. If empty, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
-#   TABNINE_CLEANUP        - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
+#   TABNINE_CLEANUP        - Set to "true" to delete settings.json after each run (default: "false"). Recommended for self-hosted runners.
 
 image: node:20
 

--- a/Bitbucket/bitbucket-pipelines.yml
+++ b/Bitbucket/bitbucket-pipelines.yml
@@ -10,6 +10,7 @@
 # Optional Repository Variables:
 #   TABNINE_HOST           - Tabnine host URL (default: https://console.tabnine.com)
 #   TABNINE_MODEL_ID       - Model ID for the Tabnine CLI agent. If empty, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
+#   TABNINE_CLEANUP        - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
 
 image: node:20
 
@@ -375,3 +376,9 @@ pipelines:
               **Comment Density Rule**: If you are about to post more than the tier's budget, re-evaluate all comments and keep only the most impactful. Developers ignore reviews with too many comments.
               PROMPT_EOF
               TABNINE_TOKEN=$TABNINE_KEY ~/.local/bin/tabnine -y -p "$(cat /tmp/tabnine_prompt.txt)"
+            # Cleanup Tabnine Settings (optional, for self-hosted runners)
+            - |
+              if [ "${TABNINE_CLEANUP}" = "true" ]; then
+                echo "Cleaning up Tabnine settings..."
+                rm -f ~/.tabnine/agent/settings.json
+              fi

--- a/GitHub/tabnine-review.yml
+++ b/GitHub/tabnine-review.yml
@@ -11,6 +11,7 @@
 # Optional Variables (set in Settings > Secrets and variables > Actions > Variables tab > "New repository variable"):
 #   TABNINE_HOST         - Tabnine host URL (default: https://console.tabnine.com). Set this for self-hosted / EMT installations.
 #   TABNINE_MODEL_ID     - Model ID for the Tabnine CLI agent. If empty, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
+#   TABNINE_CLEANUP      - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
 
 name: "Tabnine PR Review Agent"
 
@@ -415,3 +416,11 @@ jobs:
           - Restating what the code does without adding insight
 
           **Comment Density Rule**: If you are about to post more than the tier's budget, re-evaluate all comments and keep only the most impactful. Developers ignore reviews with too many comments."
+
+      - name: Cleanup Tabnine Settings
+        if: always() && vars.TABNINE_CLEANUP == 'true'
+        shell: bash
+        run: |
+          # Remove settings.json to prevent sensitive auth data from persisting
+          # between runs on self-hosted / named runners (e.g. GHES environments).
+          rm -f ~/.tabnine/agent/settings.json

--- a/GitHub/tabnine-review.yml
+++ b/GitHub/tabnine-review.yml
@@ -11,7 +11,7 @@
 # Optional Variables (set in Settings > Secrets and variables > Actions > Variables tab > "New repository variable"):
 #   TABNINE_HOST         - Tabnine host URL (default: https://console.tabnine.com). Set this for self-hosted / EMT installations.
 #   TABNINE_MODEL_ID     - Model ID for the Tabnine CLI agent. If empty, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
-#   TABNINE_CLEANUP      - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
+#   TABNINE_CLEANUP      - Set to "true" to delete settings.json after each run (default: "false"). Recommended for self-hosted runners.
 
 name: "Tabnine PR Review Agent"
 

--- a/GitLab/.gitlab-ci.yml
+++ b/GitLab/.gitlab-ci.yml
@@ -10,6 +10,7 @@
 # Optional CI/CD Variables:
 #   TABNINE_HOST         - Tabnine host URL (default: https://console.tabnine.com)
 #   TABNINE_MODEL_ID     - Model ID for the Tabnine CLI agent
+#   TABNINE_CLEANUP      - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
 
 stages:
   - review
@@ -23,6 +24,7 @@ tabnine-code-review:
     # default values for optional variables
     TABNINE_HOST: "https://console.tabnine.com"
     TABNINE_MODEL_ID: ""
+    TABNINE_CLEANUP: ""
   before_script:
     
     # Input validation
@@ -384,4 +386,10 @@ tabnine-code-review:
       - Restating what the code does without adding insight
 
       **Comment Density Rule**: If you are about to post more than the tier's budget, re-evaluate all comments and keep only the most impactful. Developers ignore reviews with too many comments."
+  after_script:
+    - |
+      if [ "${TABNINE_CLEANUP}" = "true" ]; then
+        echo "Cleaning up Tabnine settings..."
+        rm -f ~/.tabnine/agent/settings.json
+      fi
   allow_failure: true

--- a/GitLab/.gitlab-ci.yml
+++ b/GitLab/.gitlab-ci.yml
@@ -24,7 +24,7 @@ tabnine-code-review:
     # default values for optional variables
     TABNINE_HOST: "https://console.tabnine.com"
     TABNINE_MODEL_ID: ""
-    TABNINE_CLEANUP: ""
+    TABNINE_CLEANUP: "false"
   before_script:
     
     # Input validation

--- a/action.yml
+++ b/action.yml
@@ -420,3 +420,11 @@ runs:
         - Restating what the code does without adding insight
 
         **Comment Density Rule**: If you are about to post more than the tier's budget, re-evaluate all comments and keep only the most impactful. Developers ignore reviews with too many comments."
+
+    - name: Cleanup Tabnine Settings
+      if: always()
+      shell: bash
+      run: |
+        # Remove settings.json to prevent sensitive auth data from persisting
+        # between runs on self-hosted / named runners (e.g. GHES environments).
+        rm -f ~/.tabnine/agent/settings.json

--- a/action.yml
+++ b/action.yml
@@ -14,7 +14,7 @@
 # Optional Inputs:
 #   tabnine_host         - Tabnine host URL (default: https://console.tabnine.com)
 #   model_id             - Model ID for the Tabnine CLI agent. If omitted, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
-#   cleanup              - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
+#   cleanup              - Set to "true" to delete settings.json after each run (default: "false"). Recommended for self-hosted runners.
 
 name: 'Tabnine: Code Review'
 description: 'AI-powered code review using Tabnine CLI Agent'
@@ -37,7 +37,7 @@ inputs:
   cleanup:
     required: false
     description: 'Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.'
-    default: ''
+    default: 'false'
   repository:
     required: true
     description: 'Repository in owner/repo format'

--- a/action.yml
+++ b/action.yml
@@ -14,6 +14,7 @@
 # Optional Inputs:
 #   tabnine_host         - Tabnine host URL (default: https://console.tabnine.com)
 #   model_id             - Model ID for the Tabnine CLI agent. If omitted, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
+#   cleanup              - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
 
 name: 'Tabnine: Code Review'
 description: 'AI-powered code review using Tabnine CLI Agent'
@@ -32,6 +33,10 @@ inputs:
   model_id:
     required: false
     description: 'Model ID for the Tabnine CLI agent. If omitted, falls back to DEFAULT_MODEL_ID below or the system default.'
+    default: ''
+  cleanup:
+    required: false
+    description: 'Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.'
     default: ''
   repository:
     required: true
@@ -422,7 +427,7 @@ runs:
         **Comment Density Rule**: If you are about to post more than the tier's budget, re-evaluate all comments and keep only the most impactful. Developers ignore reviews with too many comments."
 
     - name: Cleanup Tabnine Settings
-      if: always()
+      if: always() && inputs.cleanup == 'true'
       shell: bash
       run: |
         # Remove settings.json to prevent sensitive auth data from persisting


### PR DESCRIPTION
## Problem

Self-hosted / named GHES runners do not wipe the workspace between runs. This causes `settings.json` (which contains Tabnine auth credentials) to persist across consecutive PR review jobs, leaking state between runs.

## Fix

Add an unconditional cleanup step (`if: always()`) at the end of the composite action that deletes `~/.tabnine/agent/settings.json` after every run — on both success and failure.

## Impact

- ✅ Self-hosted / named GHES runners no longer retain `settings.json` between runs
- ✅ No impact on ephemeral GitHub-hosted runners (file is deleted either way)
- ✅ Runs unconditionally so cleanup happens even if the review step fails

Fixes [DEV3-5002](https://tabnine.atlassian.net/browse/DEV3-5002)

[DEV3-5002]: https://tabnine.atlassian.net/browse/DEV3-5002?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ