### PR TITLE
DEV3-5281: Make checkout clone depth configurable across CI providers

### DIFF
--- a/Bitbucket/bitbucket-pipelines.yml
+++ b/Bitbucket/bitbucket-pipelines.yml
@@ -12,6 +12,14 @@
 #   TABNINE_MODEL_ID       - Model ID for the Tabnine CLI agent. If empty, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
 #   TABNINE_CLEANUP        - Set to "true" to delete settings.json after each run (default: "false"). Recommended for self-hosted runners.
 #   TABNINE_COMMENT_PREFIX - Prefix used to identify bot comments for cleanup (default: '#### Tabnine PR Bot').
+#
+# Clone depth:
+#   The `clone.depth` value below controls how much git history is fetched.
+#   Bitbucket Pipelines does NOT support variable substitution for `clone.depth`, so to change it
+#   you must edit this file directly. Accepted values: a positive integer, or the literal string `full`.
+#   The built-in review uses the Bitbucket REST API and does not need local git history; the shallow
+#   default is fine. Set to `full` only if you provide a custom prompt that inspects local git history
+#   (e.g. git log, git blame).
 
 image: node:20
 
@@ -20,6 +28,8 @@ pipelines:
     '**':
       - step:
           name: Tabnine Code Review
+          clone:
+            depth: 50
           script:
             # Set a default model ID here, or leave empty to use the system default from the admin console.
             - export DEFAULT_MODEL_ID=""

--- a/GitHub/tabnine-review.yml
+++ b/GitHub/tabnine-review.yml
@@ -13,6 +13,8 @@
 #   TABNINE_MODEL_ID     - Model ID for the Tabnine CLI agent. If empty, falls back to DEFAULT_MODEL_ID below or the system default from the admin console.
 #   TABNINE_CLEANUP      - Set to "true" to delete settings.json after each run (default: "false"). Recommended for self-hosted runners.
 #   TABNINE_COMMENT_PREFIX - Prefix used to identify bot comments for cleanup (default: '#### Tabnine PR Bot').
+#   TABNINE_FETCH_DEPTH  - Clone depth for actions/checkout (default: "1", shallow). The built-in review uses the 'gh' API and does not need local git history.
+#                          Set to "0" for full history if you provide a custom prompt that inspects local git history (e.g. git log, git blame).
 
 name: "Tabnine PR Review Agent"
 
@@ -32,7 +34,11 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Clone depth. Default is 1 (shallow), which matches actions/checkout's native default and is sufficient
+          # for the built-in review (it uses the 'gh' API, not local git history).
+          # Set the repository variable TABNINE_FETCH_DEPTH to "0" for full history, or another value, if your
+          # custom prompt_override inspects local git history (e.g. git log, git blame, git diff base..head).
+          fetch-depth: ${{ vars.TABNINE_FETCH_DEPTH || 1 }}
 
       - name: Install Tabnine CLI
         shell: bash

--- a/GitLab/.gitlab-ci.yml
+++ b/GitLab/.gitlab-ci.yml
@@ -12,6 +12,9 @@
 #   TABNINE_MODEL_ID     - Model ID for the Tabnine CLI agent
 #   TABNINE_CLEANUP      - Set to "true" to delete settings.json after each run. Recommended for self-hosted runners.
 #   TABNINE_COMMENT_PREFIX - Prefix used to identify bot comments for cleanup (default: '#### Tabnine PR Bot').
+#   GIT_DEPTH            - Clone depth (default: "20", shallow). GitLab natively reads this variable to control clone depth.
+#                          The built-in review uses the GitLab REST API and does not need local git history.
+#                          Set to "0" for full history if you provide a custom prompt that inspects local git history (e.g. git log, git blame).
 
 stages:
   - review
@@ -26,6 +29,8 @@ tabnine-code-review:
     TABNINE_HOST: "https://console.tabnine.com"
     TABNINE_MODEL_ID: ""
     TABNINE_CLEANUP: "false"
+    # Shallow clone by default; override by setting GIT_DEPTH in Settings > CI/CD > Variables.
+    GIT_DEPTH: "20"
   before_script:
     
     # Input validation

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ Set the following repository secret in **Settings > Secrets and variables > Acti
 
 The action also requires a `github_token` input — typically provided via the built-in `secrets.GITHUB_TOKEN`.
 
+Optionally, set the following repository variables in **Settings > Secrets and variables > Actions > Variables**:
+
+| Variable | Required | Description |
+|---|---|---|
+| `TABNINE_HOST` | No | Tabnine host URL for self-hosted / EMT installations (default: `https://console.tabnine.com`) |
+| `TABNINE_MODEL_ID` | No | Model ID for the Tabnine CLI agent. If empty, falls back to `DEFAULT_MODEL_ID` in the workflow yml or the system default from the admin console. |
+| `TABNINE_CLEANUP` | No | Set to `"true"` to delete `settings.json` after each run. Recommended for self-hosted runners. |
+| `TABNINE_COMMENT_PREFIX` | No | Prefix used to identify bot comments for cleanup (default: `#### Tabnine PR Bot`). |
+| `TABNINE_FETCH_DEPTH` | No | Clone depth for `actions/checkout`. Default `"1"` (shallow) is sufficient — the built-in review uses the `gh` API and does not need local git history. Set to `"0"` for full history only if your `prompt_override` inspects local git history (e.g. `git log`, `git blame`). |
+
 ## Usage
 
 1. This action works only on the `pull_request` event within the workflow.
@@ -31,7 +41,7 @@ permissions:
   pull-requests: write
 ```
 
-2. Ensure that the repository is [checked out](https://github.com/actions/checkout/tree/v4#readme) with full history (`fetch-depth: 0`) within your workflow.
+2. Ensure that the repository is [checked out](https://github.com/actions/checkout/tree/v4#readme) within your workflow. The default shallow clone (`fetch-depth: 1`) is sufficient — the built-in review uses the `gh` API and does not need local git history. Set `fetch-depth: 0` for full history only if your `prompt_override` inspects local git history (e.g. `git log`, `git blame`). See the [full workflow example](#full-workflow-example) for the recommended pattern that makes the depth configurable via the `TABNINE_FETCH_DEPTH` variable.
 
 3. Add the following step to your workflow:
 
@@ -117,7 +127,9 @@ jobs:
       - name: Checkout the repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0
+          # Default is 1 (shallow). Override per-repo by setting the
+          # TABNINE_FETCH_DEPTH variable. Use 0 for full history.
+          fetch-depth: ${{ vars.TABNINE_FETCH_DEPTH || 1 }}
 
       - name: Review PR
         uses: codota/tabnine-pr-agent@v2
@@ -149,6 +161,7 @@ Set the following CI/CD variables in **Settings > CI/CD > Variables**:
 | `TABNINE_MODEL_ID` | No | Model ID for the Tabnine CLI agent. If empty, uses the system default from the admin console. |
 | `TABNINE_CLEANUP` | No | Set to `"true"` to delete `settings.json` after each run. Recommended for self-hosted runners. |
 | `TABNINE_COMMENT_PREFIX` | No | Prefix used to identify bot comments for cleanup (default: `#### Tabnine PR Bot`). |
+| `GIT_DEPTH` | No | Clone depth. Default `"20"` (shallow) is sufficient — the built-in review uses the GitLab REST API and does not need local git history. Set to `"0"` for full history only if your custom prompt inspects local git history (e.g. `git log`, `git blame`). |
 
 ## Usage
 
@@ -207,3 +220,9 @@ pipelines:
           script:
             # ... (see Bitbucket/bitbucket-pipelines.yml for full configuration)
 ```
+
+## Clone depth
+
+The step in `bitbucket-pipelines.yml` sets `clone.depth: 50`, which is sufficient — the built-in review uses the Bitbucket REST API and does not need local git history. Set to `full` for full history only if your custom prompt inspects local git history (e.g. `git log`, `git blame`).
+
+Bitbucket Pipelines does not support variable substitution for `clone.depth`, so it must be edited directly in the file rather than controlled by a repository variable.


### PR DESCRIPTION
## What

Make clone depth configurable and consistently documented across all three CI providers (GitHub Actions, GitLab CI, Bitbucket Pipelines).

## Why

The built-in review uses the `gh` / GitLab / Bitbucket REST APIs and does not need local git history — `base_sha` and `head_sha` are passed as explicit inputs. The previous `fetch-depth: 0` recommendation was unnecessary overhead, especially on large monorepos. Users who legitimately need full history (custom `prompt_override` that inspects local git) now have a clean, documented opt-in.

## Changes

- **GitHub** (`GitHub/tabnine-review.yml`): `fetch-depth: ${{ vars.TABNINE_FETCH_DEPTH || 1 }}` — override via repo variable `TABNINE_FETCH_DEPTH`.
- **GitLab** (`GitLab/.gitlab-ci.yml`): `GIT_DEPTH: "20"` default — override via CI/CD variable `GIT_DEPTH`.
- **Bitbucket** (`Bitbucket/bitbucket-pipelines.yml`): explicit `clone.depth: 50` — platform does not support variable substitution, so override means editing the file.
- **README**: aligned two-sentence description pattern across all providers; added an Optional Variables table to the GitHub section for parity with GitLab/Bitbucket.
- **`action.yml`**: intentionally unchanged. `actions/checkout` runs in the caller workflow before the composite action, so the composite cannot control clone depth.

## Defaults

All three defaults match each platform's native default, so existing users see no behavior change.

## Jira

DEV3-5281
