### PR TITLE
DEV3-5474 fix: move TABNINE_CLI_TRUST_WORKSPACE to the agent invocation step

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -130,7 +130,6 @@ runs:
       shell: bash
       env:
         GH_TOKEN_INPUT: ${{ inputs.github_token }}
-        TABNINE_CLI_TRUST_WORKSPACE: "true"
       run: |
         # Use a different env var name to avoid conflict with GITHUB_TOKEN
         echo "$GH_TOKEN_INPUT" | gh auth login --with-token
@@ -169,6 +168,7 @@ runs:
       env:
         TABNINE_TOKEN: ${{ inputs.TABNINE_KEY }}
         PROMPT_OVERRIDE: ${{ inputs.prompt_override }}
+        TABNINE_CLI_TRUST_WORKSPACE: "true"
       run: |
         if [ -z "$TABNINE_TOKEN" ]; then
           echo "Error: TABNINE_KEY is required"


### PR DESCRIPTION
## Summary

- The `TABNINE_CLI_TRUST_WORKSPACE: "true"` env added in #35 was placed on the `Authenticate GitHub CLI` step, which only runs `gh auth login` — not the tabnine CLI.
- Step-level `env:` does not flow to subsequent steps in a composite action, so by the time the actual `~/.local/bin/tabnine` invocation step ran, the env var was unset and the CLI exited with code 55:

```
Tabnine CLI is not running in a trusted directory. To proceed, either use
`--skip-trust`, set the `TABNINE_CLI_TRUST_WORKSPACE=true` environment
variable, or trust this directory in interactive mode.
Error: Process completed with exit code 55.
```

- This breaks every consumer running on `@main` after the tabnine-cli `feat(cli): secure .env loading and enforce workspace trust in headless mode` change.

## Fix

Move the env var onto the `${{ inputs.step_name }}` step (the one that actually invokes the CLI), and drop it from the gh auth step where it had no effect.

## Test plan

- [ ] Pin a downstream workflow to this branch and confirm the agent runs past the trust check
- [ ] Re-run a previously failing PR review and confirm the agent posts comments / summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)